### PR TITLE
Rework Datagram Socket parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ After installing the package, you can use the provided [opensips-mi](opensips/mi
 - `-fb` or `--fifo-fallback` - the path to the FIFO fallback file.
 - `-fd` or `--fifo-reply-dir` - the directory where the FIFO reply files are stored.
 - `--env-file` - the path to the environment file that contains the MI parameters (by default, the script will look for the `.env` file in the current directory); lower priority than the command line arguments.
+- `-ds` or `--datagram-socket` - Unix Datagram Socket.
+- `-dt` or `--datagram-timeout` - Datagram Socket timeout in seconds. Default is 0.1.
+- `-db` or `--datagram-buffer-size` - Datagram Socket buffer size in bytes. Default is 32768.
 
 #### Usage
 ```bash

--- a/opensips/mi/__main__.py
+++ b/opensips/mi/__main__.py
@@ -70,7 +70,13 @@ communication.add_argument('-fd', '--fifo-reply-dir',
 communication.add_argument('-ds', '--datagram-socket',
                            metavar='SOCK',
                            type=str,
-                           help='OpenSIPS Datagram Socket')
+                           help='OpenSIPS Unix Datagram Socket')
+communication.add_argument('-dt', '--datagram-timeout',
+                           type=int,
+                           help='OpenSIPS Datagram Socket Timeout')
+communication.add_argument('-db', '--datagram-buffer-size',
+                           type=int,
+                           help='OpenSIPS Datagram Socket Buffer Size')
 
 group = parser.add_mutually_exclusive_group(required=True)
 
@@ -135,12 +141,14 @@ def main():
         if args.datagram_socket:
             mi = OpenSIPSMI('datagram',
                             datagram_unix_socket=args.datagram_socket,
-                            timeout=0.1)
+                            datagram_timeout=args.datagram_timeout,
+                            datagram_buffer_size=args.datagram_buffer_size)
         else:
             mi = OpenSIPSMI('datagram',
                             datagram_ip=args.ip,
                             datagram_port=args.port,
-                            timeout=0.1)
+                            datagram_timeout=args.datagram_timeout,
+                            datagram_buffer_size=args.datagram_buffer_size)
     else:
         if not args.bash_complete:
             print(f'Unknown type: {args.type}')

--- a/opensips/mi/datagram.py
+++ b/opensips/mi/datagram.py
@@ -32,18 +32,17 @@ class Datagram(Connection):
         if "datagram_unix_socket" in kwargs:
             self.address = kwargs["datagram_unix_socket"]
             self.family = socket.AF_UNIX
-            self.recv_size = 65535 * 32
             with NamedTemporaryFile(prefix="opensips_mi_reply_", dir="/tmp") as nt:
                 self.recv_sock = nt.name
         elif "datagram_ip" in kwargs and "datagram_port" in kwargs:
             self.address = (kwargs["datagram_ip"], int(kwargs["datagram_port"]))
             self.family = socket.AF_INET
-            self.recv_size = 32768
             self.recv_sock = None
         else:
             raise ValueError("Either datagram_unix_socket or both datagram_ip and datagram_port are required for Datagram")
 
-        self.timeout = kwargs.get("timeout", 1)
+        self.timeout = float(kwargs.get("datagram_timeout") or 0.1)
+        self.recv_size = int(kwargs.get("datagram_buffer_size") or 32768)
 
     def execute(self, method: str, params: dict):
         jsoncmd = jsonrpc_helper.get_command(method, params)

--- a/opensips/version.py
+++ b/opensips/version.py
@@ -19,4 +19,4 @@
 
 """ OpenSIPS Package version """
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'


### PR DESCRIPTION
- Fix timeout set error when calling from `opensips-cli`.
  - Also, make the timeout Datagram Socket specific as it's the only one using it.
- Use the same default timeout for `opensips-cli`.
- Allow buffer size define.